### PR TITLE
Refactor OCRReader to TesseractOCRProvider, add IOCRProvider interfac…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Tests are written using the Catch2 testing framework. To run the tests:
 
 ```bash
 cd build/test
-./OCRReaderTests
+./TesseractOCRProviderTests
 ```
 
 ## Configuration

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -1,4 +1,4 @@
-#include "OCRReader.h"
+#include "TesseractOCRProvider.h"
 #include <iostream>
 
 int main(int argc, char** argv) {
@@ -10,8 +10,8 @@ int main(int argc, char** argv) {
     std::string imagePath = argv[1];
 
     try {
-        OCRReader ocrReader;
-        std::string result = ocrReader.read(imagePath);
+        TesseractOCRProvider ocrProvider;
+        std::string result = ocrProvider.read(imagePath);
         std::cout << result << std::endl;
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;

--- a/lib/include/IOCRProvider.h
+++ b/lib/include/IOCRProvider.h
@@ -1,0 +1,11 @@
+#include <iostream>
+
+// IOCRProvider.h
+class IOCRProvider {
+public:
+    // A pure virtual function that reads an image and returns the OCR output
+    virtual std::string read(const std::string& imagePath) = 0;
+    
+    // A virtual destructor to ensure that deleting a pointer to an IOCRProvider deletes the correct object
+    virtual ~IOCRProvider() {}
+};

--- a/lib/include/TesseractOCRProvider.h
+++ b/lib/include/TesseractOCRProvider.h
@@ -1,0 +1,15 @@
+// TesseractOCRProvider.h
+#include "IOCRProvider.h"
+#include "OCRReader.h"
+
+class TesseractOCRProvider : public IOCRProvider {
+public:
+    TesseractOCRProvider() : ocrReader(std::make_unique<OCRReader>()) {}
+    
+    std::string read(const std::string& imagePath) override {
+        return ocrReader->read(imagePath);
+    }
+    
+private:
+    std::unique_ptr<OCRReader> ocrReader;
+};

--- a/lib/test/CMakeLists.txt
+++ b/lib/test/CMakeLists.txt
@@ -2,15 +2,15 @@
 find_package(Catch2 REQUIRED)
 
 # Declare your test executable
-add_executable(OCRReaderTests OCRReaderTests.cpp)
+add_executable(TesseractOCRProviderTests TesseractOCRProviderTests.cpp)
 
 # Link your library to your test executable
-target_link_libraries(OCRReaderTests PRIVATE OCRASSISTANTLIB)
+target_link_libraries(TesseractOCRProviderTests PRIVATE OCRASSISTANTLIB)
 
 # Link the Catch2 testing library to your test executable
-target_link_libraries(OCRReaderTests PRIVATE Catch2::Catch2)
+target_link_libraries(TesseractOCRProviderTests PRIVATE Catch2::Catch2)
 
-add_custom_command(TARGET OCRReaderTests POST_BUILD
+add_custom_command(TARGET TesseractOCRProviderTests POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy
                        ${CMAKE_SOURCE_DIR}/lib/test/tesseract-test-image.png
                        ${CMAKE_CURRENT_BINARY_DIR}/tesseract-test-image.png)

--- a/lib/test/TesseractOCRProviderTests.cpp
+++ b/lib/test/TesseractOCRProviderTests.cpp
@@ -1,11 +1,12 @@
+// TesseractOCRProviderTests.cpp
+
 #define CATCH_CONFIG_MAIN
 #include "catch.hpp"
-#include "OCRReader.h"
+#include "TesseractOCRProvider.h"
 #include <iostream>
 
-
-TEST_CASE("OCRReader read method test", "[OCRReader]") {
-    OCRReader ocrReader;
+TEST_CASE("TesseractOCRProvider read method test", "[TesseractOCRProvider]") {
+    TesseractOCRProvider ocrProvider;
 
     std::string imagePath = "./tesseract-test-image.png";
     std::string expectedText = R"(Running Tesseract
@@ -17,7 +18,7 @@ tesseract myscan.png out
 Or to do the same with German:
 )";
     
-    std::string result = ocrReader.read(imagePath);
+    std::string result = ocrProvider.read(imagePath);
     std::cout << result << std::endl;
     REQUIRE(result == expectedText);
 }


### PR DESCRIPTION
…e to manage OCR providers, and update related code and tests.

The code changes rename the OCRReader class to TesseractOCRProvider and introduce the IOCRProvider interface to manage multiple OCR providers. The changes are also propagated in the `main` method to use the TesseractOCRProvider to process the image. Finally, the test cases are updated to reflect the changes in the class and tests are renamed accordingly.